### PR TITLE
Fix dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source :rubygems
 
 group :development do
-  gem "rspec", "~> 2.3.0"
+  gem "rspec", ">= 2.4.0"
   gem "bundler", "> 1.0.10" # so that we know we have Psych
   gem "jeweler", "~> 1.6.4"
   gem "rcov", ">= 0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,14 +9,14 @@ GEM
       rake
     rake (0.9.2.2)
     rcov (0.9.11)
-    rspec (2.3.0)
-      rspec-core (~> 2.3.0)
-      rspec-expectations (~> 2.3.0)
-      rspec-mocks (~> 2.3.0)
-    rspec-core (2.3.1)
-    rspec-expectations (2.3.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.3.0)
+    rspec (2.9.0)
+      rspec-core (~> 2.9.0)
+      rspec-expectations (~> 2.9.0)
+      rspec-mocks (~> 2.9.0)
+    rspec-core (2.9.0)
+    rspec-expectations (2.9.0)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.9.0)
 
 PLATFORMS
   ruby
@@ -25,4 +25,4 @@ DEPENDENCIES
   bundler (> 1.0.10)
   jeweler (~> 1.6.4)
   rcov
-  rspec (~> 2.3.0)
+  rspec (>= 2.4.0)


### PR DESCRIPTION
I upgraded Bundler and RSpec dependencies.
- Bundler dependency is fixed to support 1.1.x versions too
- RSpec dependency upgraded because of https://github.com/rspec/rspec-core/pull/258 (MRI > 1.9.3 and RSpec < 2.4.0 is not works correctly).
