### PR TITLE
Fixing the Psych-related error already encountered in Localeapp

### DIFF
--- a/lib/i18n-spec.rb
+++ b/lib/i18n-spec.rb
@@ -1,4 +1,4 @@
-if defined?(Psych) and !defined?(YAML::ParseError)
+if defined?(Psych) and defined?(Psych::VERSION) and !defined?(YAML::ParseError)
   YAML::ParseError = Psych::SyntaxError
 end
 

--- a/lib/i18n-spec/models/locale_file.rb
+++ b/lib/i18n-spec/models/locale_file.rb
@@ -86,7 +86,7 @@ module I18nSpec
     end
 
     def yaml_load_content
-      if defined? Psych
+      if defined?(Psych) and defined?(Psych::VERSION)
         Psych.load(content)
       else
         YAML.load(content)


### PR DESCRIPTION
This patch prevents a Psych-related error in i18n-spec by using the same check proposed by @tenderlove in response to https://github.com/Locale/localeapp/issues/27
