### PR TITLE
Correctly require rspec to prevent load exception

### DIFF
--- a/lib/i18n-spec/matchers/be_named_like_top_level_namespace_matcher.rb
+++ b/lib/i18n-spec/matchers/be_named_like_top_level_namespace_matcher.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require 'rspec/core'
 
 RSpec::Matchers.define :be_named_like_top_level_namespace do
   match do |actual|


### PR DESCRIPTION
Requiring `rspec` rather than `rspec/core` results in the following exception on a Rails 4 application:

    ./vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.0/lib/active_support/dependencies.rb:247:in `require': cannot load such file -- rspec (LoadError)
    from ./vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.0/lib/active_support/dependencies.rb:247:in `block in require'
    from ./vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.0/lib/active_support/dependencies.rb:232:in `load_dependency'
    from ./vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.0/lib/active_support/dependencies.rb:247:in `require'
    from ./vendor/bundle/ruby/2.1.0/gems/i18n-spec-0.5.0/lib/i18n-spec/matchers/be_named_like_top_level_namespace_matcher.rb:1:in `<top (required)>'