### PR TITLE
Fix for RSpec 3

### DIFF
--- a/lib/i18n-spec/shared_examples/valid_locale_file.rb
+++ b/lib/i18n-spec/shared_examples/valid_locale_file.rb
@@ -1,4 +1,4 @@
-shared_examples_for "a valid locale file" do |locale_file|
+RSpec.shared_examples_for "a valid locale file" do |locale_file|
   describe locale_file do
     it { should be_parseable }
     it { should have_valid_pluralization_keys }


### PR DESCRIPTION
Since I upgraded to RSpec 3, I was getting this error when running `rake i18n-spec:completeness`:

```
NoMethodError: undefined method `shared_examples_for' for main:Object
/home/infertux/.rvm/gems/ruby-2.1.2/gems/i18n-spec-0.5.1/lib/i18n-spec/shared_examples/valid_locale_file.rb:1:in `<top (required)>'
```

This fixes it when RSpec is set up to not monkey patch `main` and is backward-compatible with RSpec 2.

More info at:
- https://relishapp.com/rspec/rspec-core/v/3-0/docs/configuration/global-namespace-dsl
- https://github.com/yujinakayama/transpec#monkey-patched-example-groups
