### PR TITLE
Allow aliases in translation files

### DIFF
--- a/lib/i18n-spec/models/locale_file.rb
+++ b/lib/i18n-spec/models/locale_file.rb
@@ -106,7 +106,7 @@ module I18nSpec
 
     def yaml_load_content
       if defined?(Psych) and defined?(Psych::VERSION)
-        Psych.load(content)
+        Psych.load(content, aliases: true)
       else
         YAML.load(content)
       end


### PR DESCRIPTION
When using i18n-spec with Ruby 3.x Psych.load fails when the translation files include aliases. 

This can be fixed when adding the option ```aliases: true``` to the Psych.load call.